### PR TITLE
fix sfx subdirectories not being added to character zip

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -100,7 +100,7 @@ const getAllSfxs = async (url) => {
             if (extraLinks != null)
                 validLinks = validLinks.concat(extraLinks);
         } else
-            validLinks.push(decodeURI(aTagValue));
+            validLinks.push(decodeURI(url + aTagValue));
     }
     return validLinks
 }


### PR DESCRIPTION
noticeable with the character "clonco", which has sounds/general/clonco and sounds/general/ponco subdirectories